### PR TITLE
Restructure "Get Involved" for the new Contentful setup

### DIFF
--- a/src/components/join/Role.svelte
+++ b/src/components/join/Role.svelte
@@ -1,0 +1,34 @@
+<script>
+  export let learnMoreHash = ''
+  export let applyLink = ''
+  export let title = ''
+  export let description = ''
+</script>
+
+<style>
+  div.container,
+  div.container:hover {
+    color: #333;
+  }
+
+  div.container {
+    display: block;
+    margin: 40px 0;
+  }
+
+  div.container h4 {
+    font-family: 'Interstate';
+    font-weight: bold;
+    font-size: 22px;
+    margin: 0;
+  }
+
+  div.container p {
+    margin: 8px 0;
+  }
+</style>
+
+<div class="container">
+  <h4>{title}</h4>
+  <p>{description}</p>
+</div>

--- a/src/routes/join.svelte
+++ b/src/routes/join.svelte
@@ -1,10 +1,13 @@
 <script>
   import Heading from '../components/join/Heading.svelte'
   import Footer from '../components/join/Footer.svelte'
-
-  import openRoles from '@contentful-entries/openRole'
+  import recruitmentCycles from '@contentful-entries/recruitmentCycle'
   import content from '@contentful-entry/joinPage'
   import { removeWrapperPTag } from '../contentHelpers'
+  import Role from '../components/join/Role.svelte'
+
+  const activeCycle = recruitmentCycles.find(cycle => cycle.active)
+  console.log(activeCycle.futureRoles)
 
   const scrollToSection = sectionId => {
     const section = document.getElementById(sectionId)
@@ -81,43 +84,6 @@
     margin-top: 25px;
   }
 
-  a.open-role,
-  a.open-role:hover {
-    color: #333;
-  }
-
-  a.open-role {
-    display: block;
-    margin: 40px 0;
-  }
-
-  a.open-role div.role-name {
-    display: flex;
-    align-items: center;
-  }
-
-  a.open-role h4 {
-    font-family: 'Interstate';
-    font-weight: bold;
-    font-size: 22px;
-    margin: 0;
-  }
-
-  a.open-role p {
-    margin: 8px 0;
-  }
-
-  a.open-role img.arrow-icon {
-    width: 30px;
-    height: auto;
-    margin-left: 10px;
-    transition: margin-left 0.2s;
-  }
-
-  a.open-role:hover img.arrow-icon {
-    margin-left: 15px;
-  }
-
   a.nonprofit-cta {
     display: inline-block;
     margin-top: 30px;
@@ -178,18 +144,20 @@
   <section class="content" id="students">
     <h2>Students</h2>
     <p class="tagline">
-      {@html removeWrapperPTag(content.studentTagline)}
+      {@html removeWrapperPTag(activeCycle.tagline)}
     </p>
-    <h3>Open roles</h3>
-    {#each openRoles as openRole}
-      <a class="open-role" href={openRole.applicationUrl} target="_blank">
-        <div class="role-name">
-          <h4>{openRole.name}</h4>
-          <img class="arrow-icon" src="/icons/arrow-right-dark.svg" alt="" />
-        </div>
-        <p>{openRole.description}</p>
-      </a>
-    {/each}
+    {#if activeCycle.openRoles}
+      <h3>Open roles</h3>
+      {#each activeCycle.openRoles as openRole}
+        <Role {...openRole.fields} />
+      {/each}
+    {/if}
+    {#if activeCycle.futureRoles}
+      <h3>Future roles</h3>
+      {#each activeCycle.futureRoles as futureRole}
+        <Role {...futureRole.fields} />
+      {/each}
+    {/if}
   </section>
   <section class="content" id="nonprofits">
     <h2>Nonprofits</h2>

--- a/src/routes/join.svelte
+++ b/src/routes/join.svelte
@@ -7,7 +7,6 @@
   import Role from '../components/join/Role.svelte'
 
   const activeCycle = recruitmentCycles.find(cycle => cycle.active)
-  console.log(activeCycle.futureRoles)
 
   const scrollToSection = sectionId => {
     const section = document.getElementById(sectionId)


### PR DESCRIPTION
We're restructuring Contentful to now have a "recruitmentCycle" content object! This means we can pre-load all the open roles and soon-to-be open roles to quickly switch the listings on Get Involved after recruitment.
- [X] Loads new Contentful object from Contentful
- [X] Conditionally shows open roles and future roles depending on what should display