### PR TITLE
add detailed contact methods to "Contact Us"

### DIFF
--- a/src/components/contact/Method.svelte
+++ b/src/components/contact/Method.svelte
@@ -1,0 +1,36 @@
+<script>
+    import { removeWrapperPTag } from '../../contentHelpers'
+
+    export let text
+</script>
+<style>
+    .container {
+        height: 40px;
+        margin-left: 20px;
+        line-height: 40px;
+        overflow: hidden;
+    }
+
+    .bullet {
+        width: 12.5px;
+        height: 12.5px;
+        margin-top: 3.5px;
+        display: inline-block;
+        vertical-align: middle;
+        background-color: var(--primary-red);
+    }
+
+    p {
+        margin: 0 0 0 10px;
+        display: inline-block;
+        vertical-align: middle;
+        font-family: var(--body-font);
+        font-size: inherit;
+    }
+
+</style>
+
+<div class="container">
+    <span class="bullet" />
+    <p>{@html removeWrapperPTag(text.html)}</p>
+</div>

--- a/src/routes/contact.svelte
+++ b/src/routes/contact.svelte
@@ -11,7 +11,7 @@
     font-size: 18px;
     padding: 3rem;
     grid-template-columns: 1fr 1fr;
-    gap: 3rem 5rem;
+    gap: 3rem 3rem;
     grid-template-areas:
       'heading heading'
       'methods form'
@@ -43,7 +43,7 @@
   img {
     grid-area: image;
     justify-self: left;
-    max-width: 450px;
+    max-width: 350px;
   }
   .address {
     grid-area: address;
@@ -104,7 +104,23 @@
         'form'
         'address';
     }
-    
+
+    img {
+      max-width: 450px;
+      justify-self: center;
+    }
+
+    .methods {
+      justify-self: center;
+    }
+
+    h1 {
+      text-align: center;
+    }
+
+    .methods h2 {
+      text-align: center;
+    }
   }
 </style>
 

--- a/src/routes/contact.svelte
+++ b/src/routes/contact.svelte
@@ -1,6 +1,8 @@
 <script>
   import content from '@contentful-entry/contactUs'
-  import { removeWrapperPTag } from '../contentHelpers'
+  import methods from '@contentful-entries/contactMethod'
+  import Method from '../components/contact/Method.svelte'
+
 </script>
 
 <style>
@@ -12,7 +14,7 @@
     gap: 3rem 5rem;
     grid-template-areas:
       'heading heading'
-      'info-text form'
+      'methods form'
       'image form'
       'address form';
   }
@@ -32,12 +34,15 @@
   h2 {
     font-size: 24px;
   }
-  .info-text {
-    grid-area: info-text;
+  .methods {
+    grid-area: methods;
+  }
+  .methods h2 {
+    margin-top: 0;
   }
   img {
     grid-area: image;
-    justify-self: center;
+    justify-self: left;
     max-width: 450px;
   }
   .address {
@@ -89,25 +94,29 @@
     transform: translateY(-5px);
   }
 
-  @media (max-width: 800px) {
+  @media (max-width: 820px) {
     section {
       grid-template-columns: 1fr;
       grid-template-areas:
         'image'
         'heading'
-        'info-text'
+        'methods'
         'form'
         'address';
     }
+    
   }
 </style>
 
 <section>
   <img src={content.artwork.src} alt={content.artwork.alt} />
   <h1>{content.heading}</h1>
-  <p class="info-text">
-    {@html content.infoText.inlineHtml}
-  </p>
+  <div class="methods">
+    <h2>{content.subheading}</h2>
+    {#each methods as {text}}
+      <Method {text} />
+    {/each}
+  </div>
   <div class="address">
     <h2>{content.addressHeading}</h2>
     <p>
@@ -119,6 +128,7 @@
     </p>
   </div>
   <form
+    id="form"
     method="POST"
     name="contact"
     data-netlify="true"

--- a/src/routes/contact.svelte
+++ b/src/routes/contact.svelte
@@ -106,7 +106,6 @@
     }
 
     img {
-      max-width: 450px;
       justify-self: center;
     }
 
@@ -115,6 +114,7 @@
     }
 
     h1 {
+      margin-top: 0px;
       text-align: center;
     }
 


### PR DESCRIPTION
As we continue to expand our digital presence, I want to add greater detail to the "Contact Us" page so that we can capture all the different ways that a visitor on the website can get in touch. 

So, I've built an extensible Contentful model: the **Contact Method**.  We can add & remove methods right from Contentful, allowing us to easily modify the "Contact Us" page at will.

I've currently set up the page to render bullets, but we can build sentences instead by comma-delineating each method if we want to stick with the old format.