### PR TITLE
Set up keyed project pages architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ yarn-error.log
 # For Netlify functions
 .netlify
 .env
+
+# We use yarn
+package-lock.json

--- a/src/routes/projects/[key].json.js
+++ b/src/routes/projects/[key].json.js
@@ -1,0 +1,14 @@
+import entries from '@contentful-entries/projectDetails'
+
+export async function get(req, res, next) {
+  const { key } = req.params
+  const content = entries.find(entry => entry.key === key)
+
+  if (content) {
+    res.setHeader('Content-Type', 'application/json')
+    res.end(JSON.stringify(content))
+  } else {
+    res.writeHead(404)
+    res.end()
+  }
+}

--- a/src/routes/projects/[key].svelte
+++ b/src/routes/projects/[key].svelte
@@ -1,0 +1,20 @@
+<script context="module">
+  export async function preload({ params }) {
+    const { key } = params
+
+    const res = await this.fetch(`projects/${key}.json`)
+    if (!res.ok) {
+      this.error(res.status, res.statusText)
+      return
+    }
+
+    const content = await res.json()
+    return { content }
+  }
+</script>
+
+<script>
+  export let content
+</script>
+
+<pre>{JSON.stringify(content, undefined, 4)}</pre>

--- a/src/routes/projects/index.svelte
+++ b/src/routes/projects/index.svelte
@@ -1,5 +1,5 @@
 <script>
-  import InfoCard from '../components/InfoCard/index.svelte'
+  import InfoCard from '../../components/InfoCard/index.svelte'
   import projects from '@contentful-entries/project'
 </script>
 


### PR DESCRIPTION
Every `projectDetails` entry on Contentful becomes a server-rendered JSON `/projects/[key].json`, which is fetched in the `preload()` of `/projects/[key].svelte`.

Resolves #11.