### PR TITLE
Fix roles page not autoexpanding role on fresh load

### DIFF
--- a/src/routes/about/roles.svelte
+++ b/src/routes/about/roles.svelte
@@ -1,16 +1,12 @@
-<script context="module">
-  export const preload = async ({ query }) => ({
-    selectedRole: query.role,
-  })
-</script>
-
 <script>
   import departments from '@contentful-entries/roleDepartment'
   import headerContent from '@contentful-entry/rolesHeader'
   import Department from '../../components/about-us/roles/Department'
+  import { stores } from '@sapper/app'
   import { onMount } from 'svelte'
 
-  export let selectedRole = ''
+  const { page } = stores()
+  $: selectedRole = $page.query.role
 
   const scrollToDepartment = id => {
     const section = document.getElementById(id)


### PR DESCRIPTION
Fixes #61. This actually had nothing to do with `/about/roles/?role=...` vs `/about/roles?role=...` and everything to do with client vs. server rendering.

Because the query parameter was checked during preload, the exported SSRed output had a hardcoded `{ selectedRole: undefined }` as the preload data instead of checking the query parameter on client-side load.

This PR fixes that by setting the `selectedRole` value based on the value of the `pages` store at client load.